### PR TITLE
removed references to non-existent repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ As we learn and grow, we welcome suggestions for changes.
 You can make these suggestions in one of the following ways:
 
 * If you are familiar with **git** and **GitHub**, you can fork this repository, make your changes, and submit a Pull Request.  See <a href="#contribute">"Contribute"</a>, below.
-* You may create a new issue: [https://github.com/code4lib/antiharassment-policy/issues/new](<https://github.com/code4lib/antiharassment-policy/issues/new>)
+* You may create a new issue: [https://github.com/code4lib/code-of-conduct/issues/new](<https://github.com/code4lib/antiharassment-policy/issues/new>)
 * You can send an email to one or more of the people identified as members of the [Community Support Squad](css_volunteers.md).
 
 
@@ -38,7 +38,7 @@ Discussion is welcome on the [Code4lib listserv](https://lists.clir.org/cgi-bin/
 
 ### Using Github (doesn't require knowing Git)
 
-1. Fork the codebase e.g. to https://github.com/your-username/antiharassment-policy (click the "Fork" button in the upright corner of the page)
+1. Fork the codebase e.g. to https://github.com/your-username/code-of-conduct (click the "Fork" button in the upright corner of the page)
 1. Click the link for one of the files (e.g. `code_of_conduct.md`)
 1. Click the Edit button
 1. Add a commit summary and (optionally) an extended description
@@ -47,11 +47,11 @@ Discussion is welcome on the [Code4lib listserv](https://lists.clir.org/cgi-bin/
 
 ### Using Git
 
-1. Fork the codebase e.g. to https://github.com/your-username/antiharassment-policy
+1. Fork the codebase e.g. to https://github.com/your-username/code-of-conduct
 1. Clone your fork locally (`git clone
-git@github.com:your-username/antiharassment-policy.git my-antiharassment-policy`)
+git@github.com:your-username/code-of-conduct my-code-of-conduct`)
 1. Create a branch to hold your changes (`git checkout -b my-changes`)
 1. Commit the changes you've made (`git commit -am "Some descriptive text around
 what you've added"`)
 1. Push your branch to github (`git push origin my-changes`)
-1. Create a pull request e.g. at https://github.com/your-username/antiharassment-policy/pull/new/master
+1. Create a pull request e.g. at https://github.com/your-username/code-of-conduct/pull/new/master

--- a/css_volunteers.md
+++ b/css_volunteers.md
@@ -7,7 +7,6 @@ Please respect that these are **volunteers**: they are not available 24/7; there
 
 Therefore, it would be helpful to make sure you've provided context for your concern.
 
-
 * Aaron Collier (aaron.collier@stanford.edu)
 * Bobbi Fox (bobbi@bobbifox.net)
 * Francis Kayiwa (kayiwa@pobox.com)

--- a/diversity/README.md
+++ b/diversity/README.md
@@ -46,12 +46,12 @@ http://sd24.senate.ca.gov/news/2016-11-09-joint-statement-california-legislative
 
 ## Discuss
 
-Discussion is welcome either on the [Code4lib listserv](https://listserv.nd.edu/cgi-bin/wa?SUBED1=CODE4LIB&A=1) or by creating a new issue: https://github.com/code4lib/antiharassment-policy/issues/new
+Discussion is welcome either on the [Code4lib listserv](https://listserv.nd.edu/cgi-bin/wa?SUBED1=CODE4LIB&A=1) or by creating a new issue: https://github.com/code4lib/code-of-conduct/issues/new
 
 ## Contribute
 
 ### Using Github (doesn't require knowing Git)
 
-* The Code4Lib diversity statement and the related stuff is located in a child directory "diversity" inside the 'Antiharassment Policy' repo.
+* The Code4Lib diversity statement and the related stuff is located in a child directory "diversity" inside the 'Code of Conduct' repository
 
-* See the Contribute Section (https://github.com/code4lib/antiharassment-policy/blob/master/README.md#contribute) of the README file of the parent repo 'Antiharrahssment Policy.' 
+* See the Contribute Section (https://github.com/code4lib/code-of-conduct/blob/master/README.md#contribute) of the README file of the parent repository 'Code-of-Conduct' 


### PR DESCRIPTION
When the code of conduct repository was start it was name antiharassment
and the potentially misleading references remain. This would prove to be
a hindrance to neophytes who would click on dead end links